### PR TITLE
Rust optimization commits

### DIFF
--- a/rust/experimental/server/Cargo.lock
+++ b/rust/experimental/server/Cargo.lock
@@ -2255,7 +2255,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -2550,6 +2550,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "sse-codec"
@@ -3212,6 +3221,7 @@ dependencies = [
  "serde",
  "signal-hook",
  "socket2 0.4.9",
+ "spin 0.9.8",
  "tempdir",
  "tempfile",
  "thiserror",

--- a/rust/experimental/server/Cargo.lock
+++ b/rust/experimental/server/Cargo.lock
@@ -128,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "awaitility"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46ee60785cbb3a23bde2c462098564a6337432b9fa032a62bb7ddb5e734c135d"
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3186,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "await-tree",
+ "awaitility",
  "bytes 1.5.0",
  "cap",
  "clap",

--- a/rust/experimental/server/Cargo.lock
+++ b/rust/experimental/server/Cargo.lock
@@ -266,6 +266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "cap"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f125eb85b84a24c36b02ed1d22c9dd8632f53b3cde6e4d23512f94021030003"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,6 +3181,7 @@ dependencies = [
  "async-trait",
  "await-tree",
  "bytes 1.5.0",
+ "cap",
  "clap",
  "console-subscriber",
  "crc32fast",

--- a/rust/experimental/server/Cargo.toml
+++ b/rust/experimental/server/Cargo.toml
@@ -95,6 +95,7 @@ pin-project-lite = "0.2.8"
 signal-hook = "0.3.17"
 clap = "3.0.14"
 socket2 = { version="0.4", features = ["all"]}
+cap = "0.1.2"
 
 [dependencies.hdrs]
 version = "0.3.0"

--- a/rust/experimental/server/Cargo.toml
+++ b/rust/experimental/server/Cargo.toml
@@ -96,6 +96,7 @@ signal-hook = "0.3.17"
 clap = "3.0.14"
 socket2 = { version="0.4", features = ["all"]}
 cap = "0.1.2"
+spin = "0.9.8"
 
 [dependencies.hdrs]
 version = "0.3.0"

--- a/rust/experimental/server/Cargo.toml
+++ b/rust/experimental/server/Cargo.toml
@@ -123,6 +123,7 @@ prost-build = "0.11.9"
 
 [dev-dependencies]
 env_logger = "0.10.0"
+awaitility = "0.3.1"
 
 [profile.dev]
 # re-enable debug assertions when pprof-rs fixed the reports for misaligned pointer dereferences

--- a/rust/experimental/server/README.md
+++ b/rust/experimental/server/README.md
@@ -71,11 +71,21 @@ memory_spill_low_watermark = 0.7
 ``` 
 
 #### TeraSort cost times
-| type                         |         1T         |
-|------------------------------|:------------------:|
-| vanilla uniffle (grpc-based) |  5.3min (2.3m/3m)  |
-| rust based shuffle server    | 4.6min (2.2m/2.4m) |
+| type/buffer capacity                 | 250G (compressed)  |                         comment                          |
+|--------------------------------------|:------------------:|:--------------------------------------------------------:|
+| vanilla uniffle (grpc-based)  / 10g  |  5.3min (2.3m/3m)  |                          1.9G/s                          |
+| vanilla uniffle (grpc-based)  / 300g | 5.6min (3.7m/1.9m) |              GC occurs frequently / 2.5G/s               |
+| vanilla uniffle (netty-based) / 10g  |         /          | read failed. 2.5G/s (write is better due to zero copy)   |
+| vanilla uniffle (netty-based) / 300g |         /          |                         app hang                         |
+| rust based shuffle server     / 10g  | 4.6min (2.2m/2.4m) |                         2.0 G/s                          |
+| rust based shuffle server     / 300g |  4min (1.5m/2.5m)  |                         3.5 G/s                          |
 
+
+Compared with grpc based server, rust-based server has less memory footprint and stable performance.  
+
+And Netty is still not stable for production env.
+
+In the future, rust-based server will use io_uring mechanism to improve writing performance.
 
 ## Build
 

--- a/rust/experimental/server/README.md
+++ b/rust/experimental/server/README.md
@@ -20,18 +20,20 @@ Another implementation of Apache Uniffle shuffle server
 ## Benchmark report
 
 #### Environment
-_Software_: Uniffle 0.7.0 / Hadoop 3.2.2 / Spark 3.1.2
+
+_Software_: Uniffle 0.8.0 / Hadoop 3.2.2 / Spark 3.1.2
 
 _Hardware_: Machine 96 cores, 512G memory, 1T * 4 SSD, network bandwidth 8GB/s
 
 _Hadoop Yarn Cluster_: 1 * ResourceManager + 40 * NodeManager, every machine 4T * 4 HDD
 
-_Uniffle Cluster_: 1 * Coordinator + 5 * Shuffle Server, every machine 1T * 4 SSD
+_Uniffle Cluster_: 1 * Coordinator + 1 * Shuffle Server, every machine 1T * 4 NVME SSD
 
 #### Configuration
+
 spark's conf
-``` 
-spark.executor.instances 100
+```yaml
+spark.executor.instances 400
 spark.executor.cores 1
 spark.executor.memory 2g
 spark.shuffle.manager org.apache.spark.shuffle.RssShuffleManager
@@ -39,42 +41,41 @@ spark.rss.storage.type MEMORY_LOCALFILE
 ``` 
 
 uniffle grpc-based server's conf
-``` 
-JVM XMX=130g
+``` yaml
+JVM XMX=30g
 
-...
-rss.server.buffer.capacity 100g
-rss.server.read.buffer.capacity 20g
+# JDK11 + G1 
+
+rss.server.buffer.capacity 10g
+rss.server.read.buffer.capacity 10g
 rss.server.flush.thread.alive 10
 rss.server.flush.threadPool.size 50
 rss.server.high.watermark.write 80
 rss.server.low.watermark.write 70
-...
 ``` 
 
-uniffle-x(Rust-based)'s conf
+Rust-based shuffle-server conf
 ```
 store_type = "MEMORY_LOCALFILE"
 
 [memory_store]
-capacity = "100G"
+capacity = "10G"
 
 [localfile_store]
 data_paths = ["/data1/uniffle", "/data2/uniffle", "/data3/uniffle", "/data4/uniffle"]
 healthy_check_min_disks = 0
 
 [hybrid_store]
-memory_spill_high_watermark = 0.5
-memory_spill_low_watermark = 0.4
+memory_spill_high_watermark = 0.8
+memory_spill_low_watermark = 0.7
 ``` 
 
-#### Tera Sort
-| type                         |       100G       |           1T          | 5T (run with 400 executors) |
-|------------------------------|:----------------:|:---------------------:|:---------------------------:|
-| vanilla uniffle (grpc-based) | 1.4min (29s/53s) | 12min (4.7min/7.0min) |    18.7min(12min/6.7min)    |
-| uniffle-x                    | 1.3min (28s/48s) | 11min (4.3min/6.5min) |    14min(7.8min/6.2min)     |
+#### TeraSort cost times
+| type                         |         1T         |
+|------------------------------|:------------------:|
+| vanilla uniffle (grpc-based) |  5.3min (2.3m/3m)  |
+| rust based shuffle server    | 4.6min (2.2m/2.4m) |
 
-> Tips: When running 5T on vanilla Uniffle, data sent timeouts may occur, and there can be occasional failures in client fetching the block bitmap.
 
 ## Build
 

--- a/rust/experimental/server/src/app.rs
+++ b/rust/experimental/server/src/app.rs
@@ -233,15 +233,6 @@ impl App {
         }
     }
 
-    pub fn is_buffer_ticket_exist(&self, ticket_id: i64) -> bool {
-        self.store
-            .is_buffer_ticket_exist(self.app_id.as_str(), ticket_id)
-    }
-
-    pub fn discard_tickets(&self, ticket_id: i64) -> i64 {
-        self.store.discard_tickets(self.app_id.as_str(), ticket_id)
-    }
-
     pub async fn free_allocated_memory_size(&self, size: i64) -> Result<bool> {
         self.store.free_hot_store_allocated_memory_size(size).await
     }
@@ -256,6 +247,12 @@ impl App {
         }
 
         self.store.require_buffer(ctx).await
+    }
+
+    pub async fn release_buffer(&self, ticket_id: i64) -> Result<i64, WorkerError> {
+        self.store
+            .release_buffer(ReleaseBufferContext::from(ticket_id))
+            .await
     }
 
     fn get_underlying_partition_bitmap(&self, uid: PartitionedUId) -> PartitionedMeta {
@@ -342,6 +339,17 @@ pub struct ReadingIndexViewContext {
 pub struct RequireBufferContext {
     pub uid: PartitionedUId,
     pub size: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReleaseBufferContext {
+    pub(crate) ticket_id: i64,
+}
+
+impl From<i64> for ReleaseBufferContext {
+    fn from(value: i64) -> Self {
+        Self { ticket_id: value }
+    }
 }
 
 impl RequireBufferContext {

--- a/rust/experimental/server/src/error.rs
+++ b/rust/experimental/server/src/error.rs
@@ -48,6 +48,9 @@ pub enum WorkerError {
 
     #[error("Http request failed. {0}")]
     HTTP_SERVICE_ERROR(String),
+
+    #[error("Ticket id: {0} not exist")]
+    TICKET_ID_NOT_EXIST(i64),
 }
 
 impl From<AcquireError> for WorkerError {

--- a/rust/experimental/server/src/grpc.rs
+++ b/rust/experimental/server/src/grpc.rs
@@ -103,12 +103,24 @@ impl ShuffleServer for DefaultShuffleServer {
 
     async fn unregister_shuffle(
         &self,
-        _request: Request<ShuffleUnregisterRequest>,
+        request: Request<ShuffleUnregisterRequest>,
     ) -> Result<Response<ShuffleUnregisterResponse>, Status> {
-        // todo: implement shuffle level deletion
-        info!("Accepted unregister shuffle info....");
+        let request = request.into_inner();
+        let shuffle_id = request.shuffle_id;
+        let app_id = request.app_id;
+
+        info!(
+            "Accepted unregister shuffle info for [app:{:?}, shuffle_id:{:?}]",
+            &app_id, shuffle_id
+        );
+        let status_code = self
+            .app_manager_ref
+            .unregister(app_id, shuffle_id)
+            .await
+            .map_or_else(|_e| StatusCode::INTERNAL_ERROR, |_| StatusCode::SUCCESS);
+
         Ok(Response::new(ShuffleUnregisterResponse {
-            status: StatusCode::SUCCESS.into(),
+            status: status_code.into(),
             ret_msg: "".to_string(),
         }))
     }

--- a/rust/experimental/server/src/grpc.rs
+++ b/rust/experimental/server/src/grpc.rs
@@ -446,7 +446,16 @@ impl ShuffleServer for DefaultShuffleServer {
                 },
                 blocks: partition_to_block_id.block_ids,
             };
-            let _ = app.report_block_ids(ctx);
+
+            match app.report_block_ids(ctx).await {
+                Err(e) => {
+                    return Ok(Response::new(ReportShuffleResultResponse {
+                        status: StatusCode::INTERNAL_ERROR.into(),
+                        ret_msg: e.to_string(),
+                    }))
+                }
+                _ => (),
+            }
         }
 
         Ok(Response::new(ReportShuffleResultResponse {

--- a/rust/experimental/server/src/grpc.rs
+++ b/rust/experimental/server/src/grpc.rs
@@ -149,14 +149,15 @@ impl ShuffleServer for DefaultShuffleServer {
 
         let app = app_option.unwrap();
 
-        if !app.is_buffer_ticket_exist(ticket_id) {
+        let release_result = app.release_buffer(ticket_id).await;
+        if release_result.is_err() {
             return Ok(Response::new(SendShuffleDataResponse {
                 status: StatusCode::NO_BUFFER.into(),
                 ret_msg: "No such buffer ticket id, it may be discarded due to timeout".to_string(),
             }));
         }
 
-        let ticket_required_size = app.discard_tickets(ticket_id);
+        let ticket_required_size = release_result.unwrap();
 
         let mut blocks_map = HashMap::new();
         for shuffle_data in req.shuffle_data {

--- a/rust/experimental/server/src/lib.rs
+++ b/rust/experimental/server/src/lib.rs
@@ -40,13 +40,15 @@ use crate::proto::uniffle::shuffle_server_client::ShuffleServerClient;
 use crate::proto::uniffle::shuffle_server_server::ShuffleServerServer;
 use crate::proto::uniffle::{
     GetLocalShuffleDataRequest, GetLocalShuffleIndexRequest, GetMemoryShuffleDataRequest,
-    RequireBufferRequest, SendShuffleDataRequest, ShuffleBlock, ShuffleData,
-    ShuffleRegisterRequest,
+    GetShuffleResultRequest, PartitionToBlockIds, ReportShuffleResultRequest, RequireBufferRequest,
+    SendShuffleDataRequest, ShuffleBlock, ShuffleData, ShuffleRegisterRequest,
 };
 use crate::runtime::manager::RuntimeManager;
 use crate::util::gen_worker_uid;
 use anyhow::Result;
 use bytes::{Buf, Bytes, BytesMut};
+use croaring::treemap::JvmSerializer;
+use croaring::Treemap;
 use log::info;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
@@ -164,6 +166,20 @@ pub async fn write_read_for_one_time(mut client: ShuffleServerClient<Channel>) -
 
         let response = response.into_inner();
         assert_eq!(0, response.status);
+
+        // report the finished block ids
+        client
+            .report_shuffle_result(ReportShuffleResultRequest {
+                app_id: app_id.clone(),
+                shuffle_id: 0,
+                task_attempt_id: 0,
+                bitmap_num: 0,
+                partition_to_block_ids: vec![PartitionToBlockIds {
+                    partition_id: idx,
+                    block_ids: vec![idx as i64],
+                }],
+            })
+            .await?;
     }
 
     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -173,6 +189,21 @@ pub async fn write_read_for_one_time(mut client: ShuffleServerClient<Channel>) -
 
     // firstly. read from the memory
     for idx in 0..batch_size {
+        let block_id_result = client
+            .get_shuffle_result(GetShuffleResultRequest {
+                app_id: app_id.clone(),
+                shuffle_id: 0,
+                partition_id: idx,
+            })
+            .await?
+            .into_inner();
+
+        assert_eq!(0, block_id_result.status);
+
+        let block_id_bitmap = Treemap::deserialize(&*block_id_result.serialized_bitmap)?;
+        assert_eq!(1, block_id_bitmap.iter().count());
+        assert!(block_id_bitmap.contains(idx as u64));
+
         let response_data = client
             .get_memory_shuffle_data(GetMemoryShuffleDataRequest {
                 app_id: app_id.clone(),

--- a/rust/experimental/server/src/main.rs
+++ b/rust/experimental/server/src/main.rs
@@ -232,7 +232,7 @@ fn main() -> Result<()> {
             .max_decoding_message_size(usize::MAX)
             .max_encoding_message_size(usize::MAX);
         let service_tx = tx.subscribe();
-        std::thread::spawn(move || {
+        runtime_manager.grpc_runtime.spawn_blocking(move || {
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -283,7 +283,7 @@ async fn grpc_serve(
             if let Err(err) = rx.recv().await {
                 error!("Errors on stopping the GRPC service, err: {:?}.", err);
             } else {
-                info!("GRPC service has been graceful stopped.");
+                debug!("GRPC service has been graceful stopped.");
             }
         })
         .await

--- a/rust/experimental/server/src/main.rs
+++ b/rust/experimental/server/src/main.rs
@@ -32,10 +32,13 @@ use crate::runtime::manager::RuntimeManager;
 use crate::signal::details::graceful_wait_for_signal;
 use crate::util::{gen_worker_uid, get_local_ip};
 
+use crate::mem_allocator::ALLOCATOR;
+use crate::readable_size::ReadableSize;
 use anyhow::Result;
 use clap::{App, Arg};
 use log::{debug, error, info};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::str::FromStr;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
@@ -60,6 +63,7 @@ pub mod signal;
 pub mod store;
 mod util;
 
+const MAX_MEMORY_ALLOCATION_SIZE_ENV_KEY: &str = "MAX_MEMORY_ALLOCATION_SIZE";
 const DEFAULT_SHUFFLE_SERVER_TAG: &str = "ss_v4";
 
 fn start_coordinator_report(
@@ -170,6 +174,8 @@ fn init_log(log: &LogConfig) -> WorkerGuard {
 }
 
 fn main() -> Result<()> {
+    setup_max_memory_allocation();
+
     let args_match = App::new("Uniffle Worker")
         .version("0.9.0-SNAPSHOT")
         .about("Rust based shuffle server for Apache Uniffle")
@@ -244,6 +250,13 @@ fn main() -> Result<()> {
     graceful_wait_for_signal(tx);
 
     Ok(())
+}
+
+fn setup_max_memory_allocation() {
+    let _ = std::env::var(MAX_MEMORY_ALLOCATION_SIZE_ENV_KEY).map(|v| {
+        let readable_size = ReadableSize::from_str(v.as_str()).unwrap();
+        ALLOCATOR.set_limit(readable_size.as_bytes() as usize)
+    });
 }
 
 async fn grpc_serve(

--- a/rust/experimental/server/src/mem_allocator/mod.rs
+++ b/rust/experimental/server/src/mem_allocator/mod.rs
@@ -24,9 +24,10 @@ mod imp;
 #[path = "system_std.rs"]
 mod imp;
 
-// set default allocator
+use cap::Cap;
+
 #[global_allocator]
-static ALLOC: imp::Allocator = imp::allocator();
+pub static ALLOCATOR: Cap<imp::Allocator> = Cap::new(imp::allocator(), usize::max_value());
 
 pub mod error;
 pub type AllocStats = Vec<(&'static str, usize)>;
@@ -34,6 +35,7 @@ pub type AllocStats = Vec<(&'static str, usize)>;
 // when memory-prof feature is enabled, provide empty profiling functions
 #[cfg(not(all(unix, feature = "memory-prof")))]
 mod default;
+
 #[cfg(not(all(unix, feature = "memory-prof")))]
 pub use default::*;
 

--- a/rust/experimental/server/src/store/hdfs.rs
+++ b/rust/experimental/server/src/store/hdfs.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use crate::app::{
-    PartitionedUId, ReadingIndexViewContext, ReadingViewContext, RequireBufferContext,
-    WritingViewContext,
+    PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
+    RequireBufferContext, WritingViewContext,
 };
 use crate::config::HdfsStoreConfig;
 use crate::error::WorkerError;
@@ -246,7 +246,8 @@ impl Store for HdfsStore {
         todo!()
     }
 
-    async fn purge(&self, app_id: String) -> Result<()> {
+    async fn purge(&self, ctx: PurgeDataContext) -> Result<()> {
+        let app_id = ctx.app_id;
         let app_dir = self.get_app_dir(app_id.as_str());
 
         let keys_to_delete: Vec<_> = self

--- a/rust/experimental/server/src/store/hdfs.rs
+++ b/rust/experimental/server/src/store/hdfs.rs
@@ -17,7 +17,7 @@
 
 use crate::app::{
     PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
-    RequireBufferContext, WritingViewContext,
+    ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
 use crate::config::HdfsStoreConfig;
 use crate::error::WorkerError;
@@ -243,6 +243,10 @@ impl Store for HdfsStore {
         &self,
         _ctx: RequireBufferContext,
     ) -> Result<RequireBufferResponse, WorkerError> {
+        todo!()
+    }
+
+    async fn release_buffer(&self, _ctx: ReleaseBufferContext) -> Result<i64, WorkerError> {
         todo!()
     }
 

--- a/rust/experimental/server/src/store/hybrid.rs
+++ b/rust/experimental/server/src/store/hybrid.rs
@@ -246,7 +246,7 @@ impl HybridStore {
         self.hot_store
             .release_in_flight_blocks_in_underlying_staging_buffer(uid, in_flight_blocks_id)
             .await?;
-        self.hot_store.free_memory(spill_size).await?;
+        self.hot_store.free_used(spill_size).await?;
 
         match self.get_store_type(candidate_store) {
             StorageType::LOCALFILE => {
@@ -268,6 +268,10 @@ impl HybridStore {
 
     pub fn discard_tickets(&self, app_id: &str, ticket_id: i64) -> i64 {
         self.hot_store.discard_tickets(app_id, Some(ticket_id))
+    }
+
+    pub async fn free_hot_store_allocated_memory_size(&self, size: i64) -> Result<bool> {
+        self.hot_store.free_allocated(size).await
     }
 
     pub async fn get_hot_store_memory_snapshot(&self) -> Result<MemorySnapshot> {

--- a/rust/experimental/server/src/store/hybrid.rs
+++ b/rust/experimental/server/src/store/hybrid.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::app::{
-    PartitionedUId, ReadingIndexViewContext, ReadingOptions, ReadingViewContext,
+    PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingOptions, ReadingViewContext,
     RequireBufferContext, WritingViewContext,
 };
 use crate::await_tree::AWAIT_TREE_REGISTRY;
@@ -457,24 +457,17 @@ impl Store for HybridStore {
             .await
     }
 
-    async fn purge(&self, app_id: String) -> Result<()> {
-        self.hot_store.purge(app_id.clone()).await?;
-        info!("Removed data of app:[{}] in hot store", &app_id);
+    async fn purge(&self, ctx: PurgeDataContext) -> Result<()> {
+        let app_id = &ctx.app_id;
+        self.hot_store.purge(ctx.clone()).await?;
+        info!("Removed data of app:[{}] in hot store", app_id);
         if self.warm_store.is_some() {
-            self.warm_store
-                .as_ref()
-                .unwrap()
-                .purge(app_id.clone())
-                .await?;
-            info!("Removed data of app:[{}] in warm store", &app_id);
+            self.warm_store.as_ref().unwrap().purge(ctx.clone()).await?;
+            info!("Removed data of app:[{}] in warm store", app_id);
         }
         if self.cold_store.is_some() {
-            self.cold_store
-                .as_ref()
-                .unwrap()
-                .purge(app_id.clone())
-                .await?;
-            info!("Removed data of app:[{}] in cold store", &app_id);
+            self.cold_store.as_ref().unwrap().purge(ctx.clone()).await?;
+            info!("Removed data of app:[{}] in cold store", app_id);
         }
         Ok(())
     }

--- a/rust/experimental/server/src/store/localfile.rs
+++ b/rust/experimental/server/src/store/localfile.rs
@@ -17,8 +17,8 @@
 
 use crate::app::ReadingOptions::FILE_OFFSET_AND_LEN;
 use crate::app::{
-    PartitionedUId, ReadingIndexViewContext, ReadingViewContext, RequireBufferContext,
-    WritingViewContext,
+    PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
+    RequireBufferContext, WritingViewContext,
 };
 use crate::config::LocalfileStoreConfig;
 use crate::error::WorkerError;
@@ -110,6 +110,10 @@ impl LocalFileStore {
 
     fn gen_relative_path_for_app(app_id: &str) -> String {
         format!("{}", app_id)
+    }
+
+    fn gen_relative_path_for_shuffle(app_id: &str, shuffle_id: i32) -> String {
+        format!("{}/{}", app_id, shuffle_id)
     }
 
     fn gen_relative_path_for_partition(uid: &PartitionedUId) -> (String, String) {
@@ -426,32 +430,40 @@ impl Store for LocalFileStore {
         todo!()
     }
 
-    async fn purge(&self, app_id: String) -> Result<()> {
-        let app_relative_dir_path = LocalFileStore::gen_relative_path_for_app(&app_id);
+    async fn purge(&self, ctx: PurgeDataContext) -> Result<()> {
+        let app_id = ctx.app_id;
+        let shuffle_id_option = ctx.shuffle_id;
 
-        let all_partition_ids = self.get_app_all_partitions(&app_id);
-        if all_partition_ids.is_empty() {
-            return Ok(());
-        }
+        let data_relative_dir_path = match shuffle_id_option {
+            Some(shuffle_id) => LocalFileStore::gen_relative_path_for_shuffle(&app_id, shuffle_id),
+            _ => LocalFileStore::gen_relative_path_for_app(&app_id),
+        };
 
         for local_disk_ref in &self.local_disks {
             let disk = local_disk_ref.clone();
-            disk.delete(app_relative_dir_path.to_string()).await?;
+            disk.delete(data_relative_dir_path.to_string()).await?;
         }
 
-        for (shuffle_id, partition_id) in all_partition_ids.into_iter() {
-            // delete lock
-            let uid = PartitionedUId {
-                app_id: app_id.clone(),
-                shuffle_id,
-                partition_id,
-            };
-            let (data_file_path, _) = LocalFileStore::gen_relative_path_for_partition(&uid);
-            self.partition_file_locks.remove(&data_file_path);
-        }
+        if shuffle_id_option.is_none() {
+            let all_partition_ids = self.get_app_all_partitions(&app_id);
+            if all_partition_ids.is_empty() {
+                return Ok(());
+            }
 
-        // delete disk mapping
-        self.delete_app(&app_id)?;
+            for (shuffle_id, partition_id) in all_partition_ids.into_iter() {
+                // delete lock
+                let uid = PartitionedUId {
+                    app_id: app_id.clone(),
+                    shuffle_id,
+                    partition_id,
+                };
+                let (data_file_path, _) = LocalFileStore::gen_relative_path_for_partition(&uid);
+                self.partition_file_locks.remove(&data_file_path);
+            }
+
+            // delete disk mapping
+            self.delete_app(&app_id)?;
+        }
 
         Ok(())
     }
@@ -739,8 +751,8 @@ impl LocalDisk {
 #[cfg(test)]
 mod test {
     use crate::app::{
-        PartitionedUId, ReadingIndexViewContext, ReadingOptions, ReadingViewContext,
-        WritingViewContext,
+        PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingOptions,
+        ReadingViewContext, WritingViewContext,
     };
     use crate::store::localfile::{LocalDisk, LocalDiskConfig, LocalFileStore};
 
@@ -805,11 +817,29 @@ mod test {
                 &temp_path, &app_id, "0", "0"
             )))?
         );
-        runtime.wait(local_store.purge(app_id.clone()))?;
+
+        // shuffle level purge
+        runtime
+            .wait(local_store.purge(PurgeDataContext::new(app_id.to_string(), Some(0))))
+            .expect("");
+        assert_eq!(
+            false,
+            runtime.wait(tokio::fs::try_exists(format!(
+                "{}/{}/{}",
+                &temp_path, &app_id, 0
+            )))?
+        );
+
+        // app level purge
+        runtime.wait(local_store.purge((&*app_id).into()))?;
         assert_eq!(
             false,
             runtime.wait(tokio::fs::try_exists(format!("{}/{}", &temp_path, &app_id)))?
         );
+        assert!(!local_store
+            .partition_file_locks
+            .contains_key(&format!("{}/{}/{}/{}.data", &temp_path, &app_id, 0, 0)));
+        assert!(!local_store.partition_written_disk_map.contains_key(&app_id));
 
         Ok(())
     }

--- a/rust/experimental/server/src/store/localfile.rs
+++ b/rust/experimental/server/src/store/localfile.rs
@@ -18,7 +18,7 @@
 use crate::app::ReadingOptions::FILE_OFFSET_AND_LEN;
 use crate::app::{
     PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
-    RequireBufferContext, WritingViewContext,
+    ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
 use crate::config::LocalfileStoreConfig;
 use crate::error::WorkerError;
@@ -427,6 +427,10 @@ impl Store for LocalFileStore {
         &self,
         _ctx: RequireBufferContext,
     ) -> Result<RequireBufferResponse, WorkerError> {
+        todo!()
+    }
+
+    async fn release_buffer(&self, _ctx: ReleaseBufferContext) -> Result<i64, WorkerError> {
         todo!()
     }
 

--- a/rust/experimental/server/src/store/mem/mod.rs
+++ b/rust/experimental/server/src/store/mem/mod.rs
@@ -15,32 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod ticket;
+
 pub use await_tree::InstrumentAwait;
-
-pub struct MemoryBufferTicket {
-    id: i64,
-    created_time: u64,
-    size: i64,
-}
-
-impl MemoryBufferTicket {
-    pub fn new(id: i64, created_time: u64, size: i64) -> Self {
-        Self {
-            id,
-            created_time,
-            size,
-        }
-    }
-
-    pub fn get_size(&self) -> i64 {
-        self.size
-    }
-
-    pub fn is_timeout(&self, timeout_sec: i64) -> bool {
-        crate::util::current_timestamp_sec() - self.created_time > timeout_sec as u64
-    }
-
-    pub fn get_id(&self) -> i64 {
-        self.id
-    }
-}

--- a/rust/experimental/server/src/store/mem/ticket.rs
+++ b/rust/experimental/server/src/store/mem/ticket.rs
@@ -1,0 +1,231 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::error::WorkerError;
+use crate::runtime::manager::RuntimeManager;
+use anyhow::Result;
+use dashmap::DashMap;
+use log::debug;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct Ticket {
+    id: i64,
+    created_time: u64,
+    size: i64,
+    owned_by_app_id: String,
+}
+
+impl Ticket {
+    pub fn new(ticket_id: i64, created_time: u64, size: i64, app_id: &str) -> Self {
+        Self {
+            id: ticket_id,
+            created_time,
+            size,
+            owned_by_app_id: app_id.into(),
+        }
+    }
+
+    pub fn get_size(&self) -> i64 {
+        self.size
+    }
+
+    pub fn is_timeout(&self, timeout_sec: i64) -> bool {
+        crate::util::current_timestamp_sec() - self.created_time > timeout_sec as u64
+    }
+
+    pub fn get_id(&self) -> i64 {
+        self.id
+    }
+}
+
+#[derive(Clone)]
+pub struct TicketManager {
+    // key: ticket_id
+    ticket_store: Arc<DashMap<i64, Ticket>>,
+
+    ticket_timeout_sec: i64,
+    ticket_timeout_check_interval_sec: i64,
+}
+
+impl TicketManager {
+    pub fn new<F: FnMut(i64) -> bool + Send + 'static>(
+        ticket_timeout_sec: i64,
+        ticket_timeout_check_interval_sec: i64,
+        free_allocated_size_func: F,
+        runtime_manager: RuntimeManager,
+    ) -> Self {
+        let manager = Self {
+            ticket_store: Default::default(),
+            ticket_timeout_sec,
+            ticket_timeout_check_interval_sec,
+        };
+        Self::schedule_ticket_check(manager.clone(), free_allocated_size_func, runtime_manager);
+        manager
+    }
+
+    /// check the ticket existence
+    pub fn exist(&self, ticket_id: i64) -> bool {
+        self.ticket_store.contains_key(&ticket_id)
+    }
+
+    /// Delete one ticket by its id, and it will return the allocated size for this ticket
+    pub fn delete(&self, ticket_id: i64) -> Result<i64, WorkerError> {
+        if let Some(entry) = self.ticket_store.remove(&ticket_id) {
+            Ok(entry.1.size)
+        } else {
+            Err(WorkerError::TICKET_ID_NOT_EXIST(ticket_id))
+        }
+    }
+
+    /// Delete all the ticket owned by the app id. And
+    /// it will return all the allocated size of ticket ids that owned by this app_id
+    pub fn delete_by_app_id(&self, app_id: &str) -> i64 {
+        let read_view = self.ticket_store.clone();
+        let mut deleted_ids = vec![];
+        for ticket in read_view.iter() {
+            if ticket.owned_by_app_id == *app_id {
+                deleted_ids.push(ticket.id);
+            }
+        }
+
+        let mut size = 0i64;
+        for deleted_id in deleted_ids {
+            size += self
+                .ticket_store
+                .remove(&deleted_id)
+                .map_or(0, |val| val.1.size);
+        }
+        size
+    }
+
+    /// insert one ticket managed by this ticket manager
+    pub fn insert(&self, ticket_id: i64, size: i64, created_timestamp: u64, app_id: &str) -> bool {
+        let ticket = Ticket {
+            id: ticket_id,
+            created_time: created_timestamp,
+            size,
+            owned_by_app_id: app_id.into(),
+        };
+
+        self.ticket_store
+            .insert(ticket_id, ticket)
+            .map_or(false, |_| true)
+    }
+
+    fn schedule_ticket_check<F: FnMut(i64) -> bool + Send + 'static>(
+        ticket_manager: TicketManager,
+        mut free_allocated_fn: F,
+        _runtime_manager: RuntimeManager,
+    ) {
+        thread::spawn(move || {
+            let ticket_store = ticket_manager.ticket_store;
+            loop {
+                let read_view = ticket_store.clone();
+                let mut timeout_tickets = vec![];
+                for ticket in read_view.iter() {
+                    if ticket.is_timeout(ticket_manager.ticket_timeout_sec) {
+                        timeout_tickets.push(ticket.id);
+                    }
+                }
+
+                let mut total_removed_size = 0i64;
+                for timeout_ticket_id in timeout_tickets.iter() {
+                    total_removed_size += ticket_store
+                        .remove(timeout_ticket_id)
+                        .map_or(0, |val| val.1.size);
+                }
+                if total_removed_size != 0 {
+                    free_allocated_fn(total_removed_size);
+                    debug!("remove {:#?} memory allocated tickets, release pre-allocated memory size: {:?}", timeout_tickets, total_removed_size);
+                }
+                thread::sleep(Duration::from_secs(
+                    ticket_manager.ticket_timeout_check_interval_sec as u64,
+                ));
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::runtime::manager::RuntimeManager;
+    use crate::store::mem::ticket::TicketManager;
+    use dashmap::DashMap;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+
+    #[test]
+    fn test_closure() {
+        let state = Arc::new(DashMap::new());
+        state.insert(1, 1);
+
+        fn schedule(mut callback: impl FnMut(i64) -> i64 + Send + 'static) -> JoinHandle<i64> {
+            thread::spawn(move || callback(2))
+        }
+
+        let state_cloned = state.clone();
+        let callback = move |a: i64| {
+            state_cloned.insert(a, a);
+            a + 1
+        };
+        schedule(callback).join().expect("");
+
+        assert!(state.contains_key(&2));
+    }
+
+    #[test]
+    fn test_ticket_manager() {
+        let released_size = Arc::new(Mutex::new(0));
+
+        let release_size_cloned = released_size.clone();
+        let free_allocated_size_func = move |size: i64| {
+            *(release_size_cloned.lock().unwrap()) += size;
+            true
+        };
+        let ticket_manager =
+            TicketManager::new(1, 1, free_allocated_size_func, RuntimeManager::default());
+        let app_id = "test_ticket_manager_app_id";
+
+        assert!(ticket_manager.delete(1000).is_err());
+
+        // case1
+        ticket_manager.insert(1, 10, crate::util::current_timestamp_sec() + 1, app_id);
+        ticket_manager.insert(2, 10, crate::util::current_timestamp_sec() + 1, app_id);
+        assert!(ticket_manager.exist(1));
+        assert!(ticket_manager.exist(2));
+
+        // case2
+        ticket_manager.delete(1).expect("");
+        assert!(!ticket_manager.exist(1));
+        assert!(ticket_manager.exist(2));
+
+        // case3
+        ticket_manager.delete_by_app_id(app_id);
+        assert!(!ticket_manager.exist(2));
+
+        // case4
+        ticket_manager.insert(3, 10, crate::util::current_timestamp_sec() + 1, app_id);
+        assert!(ticket_manager.exist(3));
+        awaitility::at_most(Duration::from_secs(5)).until(|| !ticket_manager.exist(3));
+        assert_eq!(10, *released_size.lock().unwrap());
+    }
+}

--- a/rust/experimental/server/src/store/memory.rs
+++ b/rust/experimental/server/src/store/memory.rs
@@ -128,8 +128,12 @@ impl MemoryStore {
         self.in_flush_buffer_size.fetch_sub(size, Ordering::SeqCst);
     }
 
-    pub async fn free_memory(&self, size: i64) -> Result<bool> {
+    pub async fn free_used(&self, size: i64) -> Result<bool> {
         self.budget.free_used(size).await
+    }
+
+    pub async fn free_allocated(&self, size: i64) -> Result<bool> {
+        self.budget.free_allocated(size).await
     }
 
     pub async fn get_required_spill_buffer(

--- a/rust/experimental/server/src/store/mod.rs
+++ b/rust/experimental/server/src/store/mod.rs
@@ -23,7 +23,8 @@ pub mod mem;
 pub mod memory;
 
 use crate::app::{
-    ReadingIndexViewContext, ReadingViewContext, RequireBufferContext, WritingViewContext,
+    PurgeDataContext, ReadingIndexViewContext, ReadingViewContext, RequireBufferContext,
+    WritingViewContext,
 };
 use crate::config::Config;
 use crate::error::WorkerError;
@@ -170,7 +171,7 @@ pub trait Store {
         &self,
         ctx: RequireBufferContext,
     ) -> Result<RequireBufferResponse, WorkerError>;
-    async fn purge(&self, app_id: String) -> Result<()>;
+    async fn purge(&self, ctx: PurgeDataContext) -> Result<()>;
     async fn is_healthy(&self) -> Result<bool>;
 }
 

--- a/rust/experimental/server/src/store/mod.rs
+++ b/rust/experimental/server/src/store/mod.rs
@@ -23,8 +23,8 @@ pub mod mem;
 pub mod memory;
 
 use crate::app::{
-    PurgeDataContext, ReadingIndexViewContext, ReadingViewContext, RequireBufferContext,
-    WritingViewContext,
+    PurgeDataContext, ReadingIndexViewContext, ReadingViewContext, ReleaseBufferContext,
+    RequireBufferContext, WritingViewContext,
 };
 use crate::config::Config;
 use crate::error::WorkerError;
@@ -167,12 +167,14 @@ pub trait Store {
         &self,
         ctx: ReadingIndexViewContext,
     ) -> Result<ResponseDataIndex, WorkerError>;
+    async fn purge(&self, ctx: PurgeDataContext) -> Result<()>;
+    async fn is_healthy(&self) -> Result<bool>;
+
     async fn require_buffer(
         &self,
         ctx: RequireBufferContext,
     ) -> Result<RequireBufferResponse, WorkerError>;
-    async fn purge(&self, ctx: PurgeDataContext) -> Result<()>;
-    async fn is_healthy(&self) -> Result<bool>;
+    async fn release_buffer(&self, ctx: ReleaseBufferContext) -> Result<i64, WorkerError>;
 }
 
 pub trait Persistent {}

--- a/rust/experimental/server/tests/write_read.rs
+++ b/rust/experimental/server/tests/write_read.rs
@@ -27,6 +27,7 @@ mod tests {
 
     use std::time::Duration;
     use tonic::transport::Channel;
+    use uniffle_worker::metric::GAUGE_MEMORY_ALLOCATED;
 
     fn create_mocked_config(grpc_port: i32, capacity: String, local_data_path: String) -> Config {
         Config {
@@ -81,6 +82,9 @@ mod tests {
         let _ = start_embedded_worker(temp_path, port).await;
 
         let client = ShuffleServerClient::connect(format!("http://{}:{}", "0.0.0.0", port)).await?;
+
+        // after one batch write/read process, the allocated memory size should be 0
+        assert_eq!(0, GAUGE_MEMORY_ALLOCATED.get());
 
         write_read_for_one_time(client).await
     }


### PR DESCRIPTION
### Rust optimization as follows

- [x] fix getting blockId failure
- [x] support unregister/finish shuffle grpc interface explicitly
- [x] fix the memory reserve when app is deleted
- [ ] Add the default GRPC and riffle tags 
- [ ] speed up report shuffle result grpc interface
- [ ] fix the buffer ticket reserve when app is deleted. 
   - [x] add test cases 
   - [x] fix the release bug when the partial data sent failed, the allocated should be released 
   - [x] refactor ticket management 
- [ ] detailed test report with GRPC_NETTY + GRPC uniffle shuffle server
- [ ] replace the current hdfs client with the native client rather than needing JAVA_HOME dependencies
- [ ] construct the end-to-end tests into github CI workflow by the spark jobs
- [x] optimize the lock performance when high concurrency of writing
- [ ] metric module optimization
- [ ] page cache missing monitor
- [ ] hack design: expose python interface to integrate with Ray using distributed scheduling